### PR TITLE
fix build script to populate title for packing nuget package

### DIFF
--- a/build/build.cake
+++ b/build/build.cake
@@ -356,6 +356,7 @@ Action<string,string> build = (solution, buildConfiguration) =>
     			.WithProperty("NoWarn", "1591") // ignore missing XML doc warnings
 				.WithProperty("TreatWarningsAsErrors", treatWarningsAsErrors.ToString())
 			    .WithProperty("Version", nugetVersion.ToString())
+			    .WithProperty("Title",  "\"" + productName + "\"")
 			    .WithProperty("Authors",  "\"" + string.Join(" ", authors) + "\"")
 			    .WithProperty("Copyright",  "\"" + copyright + "\"")
 			    .WithProperty("PackageProjectUrl",  "\"" + githubUrl + "\"")


### PR DESCRIPTION
## Description of Change ##

fix build script to populate title for packing nuget package
## Issues Resolved ##

(if this PR resolves an issue, please specify the issue number after the hash below)

* fixes #

## API Changes ##

## PR Checklist ##

- [ ] have run `./build.sh` from the `build` folder and fix any errors or failed unit tests
- [ ] code follows the style guidelines described in [Coding Style](https://github.com/BlueChilli/ChilliSource/blob/master/doc/coding-style-dotnet.md)
- [ ] changes don't break API compatibility
- [ ] code has tests if applicable
- [ ] code that is not your own has attribution
- [ ] code is adequately commented